### PR TITLE
Add logging with timestamps to healthcheck script

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -7,29 +7,37 @@
 # Environment variables:
 #   HEALTHCHECK_ENABLED - Set to "false" to disable healthcheck (default: true)
 
+
+# Logging function to echo output with a timestamp
+log() {
+    echo "[$(date '+%m/%d/%y %H:%M:%S')] $1"
+}
+
 # Allow users to disable healthcheck via environment variable
 if [ "${HEALTHCHECK_ENABLED}" = "false" ]; then
+    log "Healthcheck disabled via HEALTHCHECK_ENABLED=false"
     exit 0
 fi
 
 # Check if NGINX process is running
 if ! pgrep -x nginx > /dev/null 2>&1; then
-    echo "Healthcheck failed: NGINX process not running"
+    log "Healthcheck failed: NGINX process not running"
     exit 1
 fi
 
 # Check if Broadway process is running
 # gtk4-broadwayd for GTK4, broadwayd for GTK3
 if ! pgrep -x gtk4-broadwayd > /dev/null 2>&1 && ! pgrep -x broadwayd > /dev/null 2>&1; then
-    echo "Healthcheck failed: Broadway process not running"
+    log "Healthcheck failed: Broadway process not running"
     exit 1
 fi
 
 # Check if nicotine process is running
 if ! pgrep -f "nicotine.*--isolated" > /dev/null 2>&1; then
-    echo "Healthcheck failed: Nicotine+ process not running"
+    log "Healthcheck failed: Nicotine+ process not running"
     exit 1
 fi
 
 # All checks passed
+log "Healthcheck passed: all processes running"
 exit 0

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -19,7 +19,7 @@ if ! pgrep -x nginx > /dev/null 2>&1; then
 fi
 
 # Check if Broadway process is running
-# gtk4-broadwayd for GTK4, gtk3-broadwayd for GTK3
+# gtk4-broadwayd for GTK4, broadwayd for GTK3
 if ! pgrep -x gtk4-broadwayd > /dev/null 2>&1 && ! pgrep -x broadwayd > /dev/null 2>&1; then
     echo "Healthcheck failed: Broadway process not running"
     exit 1


### PR DESCRIPTION
Adds a log function with timestamps to the healthcheck script for better debugging and monitoring. Now logs:
- When healthcheck is disabled
- All failure reasons with timestamps
- Success message when all checks pass

This makes it easier to troubleshoot container health issues.