### PR TITLE
remove Cookie header in /socket block to prevent 400 with auth proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ location /socket {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_set_header Host $host;
+    proxy_set_header Cookie "";
+    proxy_set_header Origin "";
     proxy_read_timeout 86400;
     proxy_send_timeout 86400;
     proxy_buffering off;
@@ -228,6 +230,8 @@ your.domain.com {
 ```
 
 If you're using an authentication proxy like Authentik or Authelia, the WebSocket configuration must be applied to the reverse proxy that sits in front of the authentication layer, not within the authentication proxy itself.
+
+> **Important:** If your auth proxy (Authentik, Authelia, Keycloak + oauth2-proxy, etc.) stores sessions as cookies, the browser will send that session cookie with every request to your domain — including the WebSocket upgrade to `/socket`. The container's internal nginx has a default header buffer limit of 8k per line, and a JWT session cookie from an OIDC provider can easily exceed this, causing a **400 Bad Request** that kills the WebSocket connection before it ever reaches Broadway. The fix is to strip the cookie in your `/socket` location block, which is why `proxy_set_header Cookie "";` is included in the nginx example above. Broadway does not use cookies, so this has no functional impact.
 
 Updating Nicotine+ (OPTIONAL)
 -----------------------------


### PR DESCRIPTION
## Changes
- Added `proxy_set_header Cookie "";` and `proxy_set_header Origin "";` to the nginx `/socket` example in the README
- Added a note under the authentication proxy section explaining why this is necessary and what happens if it's omitted

## Fix
Strip the `Cookie` and `Origin` headers in the `/socket` proxy location so they are never forwarded to the container's internal nginx. Broadway does not use cookies, so this has no functional impact.

```nginx
location /socket {
    ...
    proxy_set_header Cookie "";
    proxy_set_header Origin "";
    ...
}
```

## Problem
When running this image behind an authentication proxy (Keycloak + oauth2-proxy, Authentik, Authelia, etc.), the Broadway WebSocket connection fails with a 400 error:

```
broadway.js:3224 WebSocket connection to 'wss://your.domain.com/socket' failed
```

Auth works fine, the UI loads, and the container is accessible locally on port 6565 so it's not immediately obvious what's wrong.

OIDC/OAuth2 auth proxies store sessions as a JWT cookie in the browser. The browser sends this cookie with every request to the domain, including the WebSocket upgrade to `/socket`. The container's internal nginx (which proxies Broadway on port 8085) has a default `large_client_header_buffers 4 8k` limit. A JWT from an OIDC provider like Keycloak easily exceeds 8k, so the internal nginx returns a 400 before the request ever reaches Broadway.