### PR TITLE
Switch to GTK4 Broadway fork with clipboard, touchscreen, bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION} AS base
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Set environment variables
@@ -81,3 +82,27 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 # Run Nicotine+ startup script
 CMD ["init.sh"]
+
+# Install patched GTK Broadway library from prebuilt .deb
+FROM base
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PATCH_RELEASE=v1
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates wget; \
+    . /etc/os-release; \
+    case "${VERSION_ID}" in \
+      24.04) gtk_ver="4.14.5" ;; \
+      26.04) gtk_ver="4.22.2" ;; \
+      *) echo "No Broadway GTK fork release mapped for Ubuntu ${VERSION_ID}" >&2; exit 1 ;; \
+    esac; \
+    case "${PATCH_RELEASE}" in v*) ;; *) echo "PATCH_RELEASE must be a vN tag, got '${PATCH_RELEASE}'" >&2; exit 1 ;; esac; \
+    arch="$(dpkg --print-architecture)"; \
+    deb="gtk4-broadway-fork_${gtk_ver}-${PATCH_RELEASE#v}_${arch}.deb"; \
+    url="https://github.com/droserasprout/gtk-broadway/releases/download/${PATCH_RELEASE}"; \
+    wget -O /tmp/gtk-broadway-fork.deb "${url}/${deb}"; \
+    apt-get install -y --no-install-recommends /tmp/gtk-broadway-fork.deb; \
+    apt-mark hold libgtk-4-1 libgtk-4-bin; \
+    rm -f /tmp/gtk-broadway-fork.deb; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR updates Dockerfile to install GTK Broadway library fork introducing the following features:

- **Clipboard** - bidirectional copy/paste between app and browser, no permission prompt, multi-client safe.
- **Touch editing** - selection handles and the Cut/Copy/Paste bubble, reliable taps, tap-outside to dismiss popovers.
- **On-screen keyboard** - shows/hides on Android, with IME and non-Latin input (Cyrillic, CJK, gesture-typing, autocorrect).
- **Pinch to zoom** - two-finger UI zoom (0.25x-5x), crisp re-render, per-client, survives refresh.
- **Open links** - clicked links open in a new browser tab (`gtk_show_uri`, `GtkUriLauncher`, `GtkLabel`/`GtkLinkButton`).
- **Notebook tabs** - drag or wheel to scroll the tab strip on touch, with edge fades and persisted position.
- **Various bugfixes**

  Patched GTK repo: https://github.com/droserasprout/gtk-broadway
  v1 assets and changelog: https://github.com/droserasprout/gtk-broadway/releases/tag/v1