### PR TITLE
Bugfixes: smooth scrolling, modals dim, compose key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
-ARG BROTWAY_RELEASE=v3.1.1
+ARG BROTWAY_RELEASE=v3.1.2
 ARG GTK_VERSION=4.22.4
 
 # Set environment variables


### PR DESCRIPTION
No new features this time, only upstream code bugfixes 🙃

- Don't show no-op Minimize button in window menu and CSD.
- Dialog windows no longer snap top-left and grow when clicking the window below.
- Menus and popovers on a non-maximized window open at correct position.
- Modal dialogs now dim the window behind them and block its hover/clicks.
- Desktop: compose key, dead key, and IME sequences now reach the app.
- Desktop: smooth mouse-wheel and touchpad scrolling; use precise deltas instead of a fixed step per event.
- Blink/WebKit: Ctrl+scroll now zooms the app instead of pinch-zoom of the visual viewport.
- Notebook tab-strip edge fade no longer dissolves the header's bottom border.
