### PR TITLE
Brotway 3.1.3: bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:26.04
 ARG DEBIAN_FRONTEND=noninteractive
-ARG BROTWAY_RELEASE=v3.1.2
+ARG BROTWAY_RELEASE=v3.1.3
 ARG GTK_VERSION=4.22.4
 
 # Set environment variables


### PR DESCRIPTION
https://github.com/droserasprout/gtk-brotway/releases/tag/v3.1.3

- The triple-Shift debug menu now stays interactive while a menu or popup grab is open.
- Nested menus: the Left arrow closes only the open submenu, keeping the parent menu open and focused, instead of dismissing the whole chain.
- Menu-item highlight no longer flickers or clears when a submenu opens or closes.
- A CSD window drag no longer swallows the first click made afterwards.
- Notebook: clicking an end action widget (e.g. a tab-list menu button) no longer also switches the active tab.
